### PR TITLE
fix: show correct total amount in pos sale modal (#66)

### DIFF
--- a/Modules/Sale/Resources/views/pos/index.blade.php
+++ b/Modules/Sale/Resources/views/pos/index.blade.php
@@ -31,35 +31,10 @@
 @endsection
 
 @push('page_scripts')
-    <script src="{{ asset('js/jquery-mask-money.js') }}"></script>
     <script>
         $(document).ready(function () {
             window.addEventListener('showCheckoutModal', event => {
                 $('#checkoutModal').modal('show');
-
-                $('#paid_amount').maskMoney({
-                    prefix:'{{ settings()->currency->symbol }}',
-                    thousands:'{{ settings()->currency->thousand_separator }}',
-                    decimal:'{{ settings()->currency->decimal_separator }}',
-                    allowZero: false,
-                });
-
-                $('#total_amount').maskMoney({
-                    prefix:'{{ settings()->currency->symbol }}',
-                    thousands:'{{ settings()->currency->thousand_separator }}',
-                    decimal:'{{ settings()->currency->decimal_separator }}',
-                    allowZero: true,
-                });
-
-                $('#paid_amount').maskMoney('mask');
-                $('#total_amount').maskMoney('mask');
-
-                $('#checkout-form').submit(function () {
-                    var paid_amount = $('#paid_amount').maskMoney('unmasked')[0];
-                    $('#paid_amount').val(paid_amount);
-                    var total_amount = $('#total_amount').maskMoney('unmasked')[0];
-                    $('#total_amount').val(total_amount);
-                });
             });
         });
     </script>

--- a/resources/views/livewire/pos/includes/checkout-modal.blade.php
+++ b/resources/views/livewire/pos/includes/checkout-modal.blade.php
@@ -32,13 +32,15 @@
                                 <div class="col-lg-6">
                                     <div class="form-group">
                                         <label for="total_amount">Total Amount <span class="text-danger">*</span></label>
-                                        <input id="total_amount" type="text" class="form-control" name="total_amount" value="{{ $total_amount }}" readonly required>
+                                        <input id="total_amount" type="text" class="form-control" name="total_amount" value="{{ $total_amount }}" readonly required hidden>
+                                        <input id="masked_total_amount" type="text" class="form-control" name="masked_total_amount" value="{{ format_currency($total_amount) }}" readonly>
                                     </div>
                                 </div>
                                 <div class="col-lg-6">
                                     <div class="form-group">
                                         <label for="paid_amount">Received Amount <span class="text-danger">*</span></label>
-                                        <input id="paid_amount" type="text" class="form-control" name="paid_amount" value="{{ $total_amount }}" required>
+                                        <input id="paid_amount" type="text" class="form-control" name="paid_amount" value="{{ $total_amount }}" required hidden>
+                                        <input id="masked_paid_amount" type="text" class="form-control" name="masked_paid_amount" value="{{ format_currency($total_amount) }}">
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Close #66 
The jquery-mask-money plugin causes the bug by not using the latest total amount value. I have done away with the plugin in the checkout page and instead used the internal format_currency function, reducing external dependencies.